### PR TITLE
chore(ci): bump the node version to 20

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
     - name: Run test
       run: |
         npm install -g yarn

--- a/.github/workflows/ci-pre-merge.yml
+++ b/.github/workflows/ci-pre-merge.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '20'
     - name: Run test
       run: |
         npm install -g yarn
@@ -25,9 +25,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
     - run: |
         npm install -g yarn
         rm -rf node_modules && yarn install
     - run: yarn run lint
-

--- a/.github/workflows/ci-update-swagger.yml
+++ b/.github/workflows/ci-update-swagger.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
     - uses: webfactory/ssh-agent@v0.9.0
       with:
         ssh-private-key: ${{ secrets.CI_ROBOT_SSH_PRIVATE_KEY }}

--- a/.github/workflows/manual-update-swagger.yml
+++ b/.github/workflows/manual-update-swagger.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
     - uses: webfactory/ssh-agent@v0.9.0
       with:
         ssh-private-key: ${{ secrets.CI_ROBOT_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
https://github.com/llmariner/swagger-merger/actions/runs/13435110789/job/37535539579 faled with the following error:

error rimraf@6.0.1: The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "18.20.6" error Found incompatible module.
/home/runner/work/swagger-merger/swagger-merger/node_modules/zx/build/core.cjs:203
          const output = new ProcessOutput(dto);
                         ^