### PR TITLE
feat: update the reviewer list to include only `takeshi` for now

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,7 @@ import { merge } from './merger.js';
 $.verbose = false;
 
 const reviewers = [
-  'guangrui-cloudnatix',
-  'kenji-cloudnatix',
   'takeshi-cloudnatix',
-  'aya-cloudnatix',
 ];
 
 // In the actions runner, the access token should be stored


### PR DESCRIPTION
Due to the limitation (only 1 reviewer) on the `llmariner/frontend` repo (private and free), this script results in always assigning Guangrui to generated PRs.

For now, let me replace it with myself.

Anyway, I've been watching the repo.